### PR TITLE
Use .NET 6 preview.6 explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN python3 -m venv .venv &&\
 ############################################################
 # Final base image
 ############################################################
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0 as lynxbase
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0-preview.6 as lynxbase
 
 ############################################################
 # Create final Lynx image


### PR DESCRIPTION
There seem to be an issue with .NET 6 preview.6 in ARM64.